### PR TITLE
Fix crash if app resumes after a certain inactivity

### DIFF
--- a/android/src/main/java/org/wonday/orientation/OrientationModule.java
+++ b/android/src/main/java/org/wonday/orientation/OrientationModule.java
@@ -231,6 +231,7 @@ public class OrientationModule extends ReactContextBaseJavaModule implements Lif
 
         final Activity activity = getCurrentActivity();
         assert activity != null;
+        if (activity == null) return;
         activity.registerReceiver(receiver, new IntentFilter("onConfigurationChanged"));
     }
     @Override


### PR DESCRIPTION
Reproduced lots of times on our production [app](https://play.google.com/store/apps/details?id=com.wattpad.raccoon.android)
I don't see potential problem with return early and we cannot reproduce it in our dev environment