### PR TITLE
Update build.gradle for RN 0.57

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,38 +1,16 @@
 apply plugin: 'com.android.library'
 
-def _ext = rootProject.ext
-
-/* 
-    If you want to change this properties, just put them on your android/build.gradle like this:
-
-    buildscript {
-        ...
-    }
-
-    ext {
-        compileSdkVersion = 27
-        minSdkVersion = 16
-        targetSdkVersion = 27
-        buildToolsVersion = "27.0.3"
-    }
-
-    allprojects {
-        ...
-    }
-*/
-def _reactNativeVersion = _ext.has('reactNative') ? _ext.reactNative : '+'
-def _compileSdkVersion = _ext.has('compileSdkVersion') ? _ext.compileSdkVersion : 27
-def _buildToolsVersion = _ext.has('buildToolsVersion') ? _ext.buildToolsVersion : '27.0.3'
-def _minSdkVersion = _ext.has('minSdkVersion') ? _ext.minSdkVersion : 16
-def _targetSdkVersion = _ext.has('targetSdkVersion') ? _ext.targetSdkVersion : 27
+def safeExtGet(prop, fallback) {
+    rootProject.ext.has(prop) ? rootProject.ext.get(prop) : fallback
+}
 
 android {
-    compileSdkVersion _compileSdkVersion
-    buildToolsVersion _buildToolsVersion
+    compileSdkVersion safeExtGet('compileSdkVersion', 27)
+    buildToolsVersion safeExtGet('buildToolsVersion', '27.0.3')
 
     defaultConfig {
-        minSdkVersion _minSdkVersion
-        targetSdkVersion _targetSdkVersion
+        minSdkVersion safeExtGet('minSdkVersion', 16)
+        targetSdkVersion safeExtGet('targetSdkVersion', 26)
         versionCode 1
         versionName "1.0"
         ndk {
@@ -42,5 +20,5 @@ android {
 }
 
 dependencies {
-    implementation "com.facebook.react:react-native:${_reactNativeVersion}"
+    implementation "com.facebook.react:react-native:${safeExtGet('reactNative', '+')}"
 }

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,12 +1,38 @@
 apply plugin: 'com.android.library'
 
+def _ext = rootProject.ext
+
+/* 
+    If you want to change this properties, just put them on your android/build.gradle like this:
+
+    buildscript {
+        ...
+    }
+
+    ext {
+        compileSdkVersion = 27
+        minSdkVersion = 16
+        targetSdkVersion = 27
+        buildToolsVersion = "27.0.3"
+    }
+
+    allprojects {
+        ...
+    }
+*/
+def _reactNativeVersion = _ext.has('reactNative') ? _ext.reactNative : '+'
+def _compileSdkVersion = _ext.has('compileSdkVersion') ? _ext.compileSdkVersion : 27
+def _buildToolsVersion = _ext.has('buildToolsVersion') ? _ext.buildToolsVersion : '27.0.3'
+def _minSdkVersion = _ext.has('minSdkVersion') ? _ext.minSdkVersion : 16
+def _targetSdkVersion = _ext.has('targetSdkVersion') ? _ext.targetSdkVersion : 27
+
 android {
-    compileSdkVersion 26
-    buildToolsVersion "26.0.3"
+    compileSdkVersion _compileSdkVersion
+    buildToolsVersion _buildToolsVersion
 
     defaultConfig {
-        minSdkVersion 16
-        targetSdkVersion 26
+        minSdkVersion _minSdkVersion
+        targetSdkVersion _targetSdkVersion
         versionCode 1
         versionName "1.0"
         ndk {
@@ -16,5 +42,5 @@ android {
 }
 
 dependencies {
-    compile "com.facebook.react:react-native:+"
+    implementation "com.facebook.react:react-native:${_reactNativeVersion}"
 }


### PR DESCRIPTION
React Native 0.57 [scaffolds new projects using Gradle 3, instead of Gradle 2](https://github.com/facebook/react-native/commit/6eac2d4e2f5f697043b495002872bfac3e8595cb).

Users who install this library with Gradle 3 will see the following error:

```
Configuration 'compile' is obsolete and has been replaced with 'implementation' and 'api'.
It will be removed at the end of 2018. For more information see: http://d.android.com/r/tools/update-dependency-configurations.html
```

This PR fixes this warning.

Please note: this will cause any users who are still on Gradle 2 to see an error:

```
> Could not find method implementation() for arguments [com.facebook.react:react-native:+] on object of type org.gradle.api.internal.artifacts.dsl.dependencies.DefaultDependencyHandler.
```

This is because `implementation` is only available for users of Gradle 3.

It may therefore be worth bumping the major version of this lib to indicate a breaking change for some users.