### PR TITLE
added method to check if system auto-rotate is enabled

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,8 +8,11 @@ A react-native module that can listen on orientation changing of device, get cur
 * lock screen orientation to PORTRAIT|LANDSCAPE-LEFT|PORTRAIT-UPSIDEDOWN|LANDSCAPE-RIGHT.
 * listen on orientation changing of device
 * get the current orientation of device
- 
+
  ### ChangeLog
+
+v1.0.22  
+ 1. add getAutoRotateState()
 
 v1.0.21
 1. add getDeviceOrientation()
@@ -88,7 +91,7 @@ Implement onConfigurationChanged method (in `MainActivity.java`)
 +import android.content.res.Configuration;
 
 public class MainActivity extends ReactActivity {
-    
+
 +   @Override
 +   public void onConfigurationChanged(Configuration newConfig) {
 +       super.onConfigurationChanged(newConfig);
@@ -134,6 +137,9 @@ import Orientation from 'react-native-orientation-locker';
 
   componentDidMount() {
 
+    Orientation.getAutoRotateState((rotationLock) => this.setState({rotationLock}));
+    //this allows to check if the system autolock is enabled or not.
+
     Orientation.lockToPortrait(); //this will lock the view to Portrait
     //Orientation.lockToLandscapeLeft(); //this will lock the view to Landscape
     //Orientation.unlockAllOrientations(); //this will unlock the view to all Orientations
@@ -172,13 +178,14 @@ orientation can return either `PORTRAIT` `LANDSCAPE-LEFT` `LANDSCAPE-RIGHT` `POR
 - `unlockAllOrientations()`
 - `getOrientation(function(orientation))`
 - `getDeviceOrientation(function(orientation))`
+- `getAutoRotateState(function(state))`
 
 orientation can return one of:
 
-- `PORTRAIT` 
+- `PORTRAIT`
 - `LANDSCAPE-LEFT` camera left home button right
 - `LANDSCAPE-RIGHT` camera right home button left
-- `PORTRAIT-UPSIDEDOWN` 
+- `PORTRAIT-UPSIDEDOWN`
 - `UNKNOWN`
 
 Notice: PORTRAIT-UPSIDEDOWN not support at iOS now

--- a/android/src/main/java/org/wonday/orientation/OrientationModule.java
+++ b/android/src/main/java/org/wonday/orientation/OrientationModule.java
@@ -1,6 +1,6 @@
 //
 //  react-native-orientation-locker
-//  
+//
 //
 //  Created by Wonday on 17/5/12.
 //  Copyright (c) wonday.org All rights reserved.
@@ -10,6 +10,7 @@ package org.wonday.orientation;
 
 import android.app.Activity;
 import android.content.BroadcastReceiver;
+import android.content.ContentResolver;
 import android.content.Context;
 import android.content.Intent;
 import android.content.IntentFilter;
@@ -37,7 +38,7 @@ import java.util.Map;
 import javax.annotation.Nullable;
 
 public class OrientationModule extends ReactContextBaseJavaModule implements LifecycleEventListener{
-    
+
     final BroadcastReceiver receiver;
     final OrientationEventListener mOrientationListener;
     final ReactApplicationContext ctx;
@@ -52,7 +53,7 @@ public class OrientationModule extends ReactContextBaseJavaModule implements Lif
         mOrientationListener = new OrientationEventListener(reactContext) {
 
             @Override
-            public void onOrientationChanged(int orientation) { 
+            public void onOrientationChanged(int orientation) {
 
                 FLog.d(ReactConstants.TAG,"DeviceOrientation changed to " + orientation);
 
@@ -138,7 +139,7 @@ public class OrientationModule extends ReactContextBaseJavaModule implements Lif
 
             }
         };
-        ctx.addLifecycleEventListener(this);       
+        ctx.addLifecycleEventListener(this);
     }
 
     @Override
@@ -222,6 +223,15 @@ public class OrientationModule extends ReactContextBaseJavaModule implements Lif
         this.isLocked = false;
     }
 
+    @ReactMethod
+    public void getAutoRotateState(Callback callback) {
+      final ContentResolver resolver = ctx.getContentResolver();
+      boolean rotateLock = android.provider.Settings.System.getInt(
+      resolver,
+      android.provider.Settings.System.ACCELEROMETER_ROTATION, 0) == 1;
+      callback.invoke(rotateLock);
+    }
+
     @Override
     public @Nullable Map<String, Object> getConstants() {
         HashMap<String, Object> constants = new HashMap<String, Object>();
@@ -254,7 +264,7 @@ public class OrientationModule extends ReactContextBaseJavaModule implements Lif
         }
         catch (java.lang.IllegalArgumentException e) {
             FLog.w(ReactConstants.TAG, "receiver already unregistered", e);
-        }        
+        }
     }
 
     @Override
@@ -270,6 +280,6 @@ public class OrientationModule extends ReactContextBaseJavaModule implements Lif
         }
         catch (java.lang.IllegalArgumentException e) {
             FLog.w(ReactConstants.TAG, "receiver already unregistered", e);
-        }        
+        }
     }
 }

--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 //
 //  react-native-orientation-locker
-//  
+//
 //
 //  Created by Wonday on 17/5/12.
 //  Copyright (c) wonday.org All rights reserved.
@@ -114,4 +114,11 @@ export default class Orientation {
         return OrientationNative.initialOrientation;
 
     };
+
+    static getAutoRotateState = (cb) => {
+      OrientationNative.getAutoRotateState((state) => {
+        cb(state);
+      });
+
+    }
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "react-native-orientation-locker",
-    "version": "1.0.21",
+    "version": "1.0.22",
     "summary": "A react-native module that can listen on orientation changing of device",
     "description": "A react-native module that can listen on orientation changing of device, get current orientation, lock to preferred orientation.",
     "homepage": "https://github.com/wonday/react-native-orientation-locker",


### PR DESCRIPTION
This PR aims to implement the feature request that is discussed in issue #25 
I have implemented it on Android only. 

Here's the usage of the new method:
Returns `true` if rotation is enabled, otherwise `false`.
```javascript
Orientation.getAutoRotateState((state) => console.log(state));
```

--------
Other than that, I have deleted unnecessary out-of-place spaces