### PR TITLE
Remove setTimout from orientation listener

### DIFF
--- a/index.js
+++ b/index.js
@@ -91,9 +91,7 @@ export default class Orientation {
         var key = getKey(cb);
         listeners[key] = LocalEventEmitter.addListener("orientationDidChange",
             (body) => {
-                setTimeout(()=>{
-                    cb(body.orientation,body.deviceOrientation);
-                },1000);
+                cb(body.orientation, body.deviceOrientation);
             });
 
     };


### PR DESCRIPTION
For issue: https://github.com/wonday/react-native-orientation-locker/issues/35

This removes this `setTimeout` in the event listener.  This is adding some performance issues in apps, and timeouts are not an ideal solution in React Native, as they can be the source of memory leaks.