### PR TITLE
Fix typescript declarations

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,5 +1,3 @@
-import {Orientation} from "react-native-orientation-locker";
-
 /**
  * Copyright (c) 2017-present, Wonday (@wonday.org)
  * All rights reserved.
@@ -8,27 +6,22 @@ import {Orientation} from "react-native-orientation-locker";
  * LICENSE file in the root directory of this source tree.
  */
 
-declare module 'react-native-orientation-locker' {
-    namespace Orientation {
-        type Orientation = "PORTRAIT" | "PORTRAIT-UPSIDEDOWN" | "LANDSCAPE-LEFT" | "LANDSCAPE-RIGHT" | "UNKNOWN";
-
-        export function addOrientationListener(callback: (orientation: Orientation) => void): void;
-        export function removeOrientationListener(callback: (orientation: Orientation) => void): void;
-        export function addDeviceOrientationListener(callback: (deviceOrientation: Orientation) => void): void;
-        export function removeDeviceOrientationListener(callback: (deviceOrientation: Orientation) => void): void;
-        export function addLockListener(callback: (orientation: Orientation) => void): void;
-        export function removeLockListener(callback: (orientation: Orientation) => void): void;
-
-        export function getInitialOrientation(): Orientation;
-        export function lockToPortrait(): void;
-        export function lockToLandscape(): void;
-        export function lockToLandscapeLeft(): void;
-        export function lockToLandscapeRight(): void;
-        export function unlockAllOrientations(): void;
-        export function getOrientation(callback: (orientation: Orientation) => void): void;
-        export function getDeviceOrientation(callback: (orientation: Orientation) => void): void;
-        export function getAutoRotateState(callback: (state: boolean) => void): void;
-    }
-
-    export = Orientation;
+export type OrientationType = "PORTRAIT" | "PORTRAIT-UPSIDEDOWN" | "LANDSCAPE-LEFT" | "LANDSCAPE-RIGHT" | "UNKNOWN";
+declare class Orientation {
+  static addOrientationListener(callback: (orientation: OrientationType) => void): void;
+  static removeOrientationListener(callback: (orientation: OrientationType) => void): void;
+  static addDeviceOrientationListener(callback: (deviceOrientation: OrientationType) => void): void;
+  static removeDeviceOrientationListener(callback: (deviceOrientation: OrientationType) => void): void;
+  static addLockListener(callback: (orientation: OrientationType) => void): void;
+  static removeLockListener(callback: (orientation: OrientationType) => void): void;
+  static getInitialOrientation(): OrientationType;
+  static lockToPortrait(): void;
+  static lockToLandscape(): void;
+  static lockToLandscapeLeft(): void;
+  static lockToLandscapeRight(): void;
+  static unlockAllOrientations(): void;
+  static getOrientation(callback: (orientation: OrientationType) => void): void;
+  static getDeviceOrientation(callback: (orientation: OrientationType) => void): void;
+  static getAutoRotateState(callback: (state: boolean) => void): void;
 }
+export default Orientation;

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
     "description": "A react-native module that can listen on orientation changing of device, get current orientation, lock to preferred orientation.",
     "homepage": "https://github.com/wonday/react-native-orientation-locker",
     "main": "index.js",
+    "types": "index.d.ts",
     "repository": {
         "type": "git",
         "url": "git+https://github.com/wonday/react-native-orientation-locker.git"


### PR DESCRIPTION
Hi @wonday  and thank you for this great library! I had issues with the declaration files and provided a few fixes:

1. TS2666: ![image](https://user-images.githubusercontent.com/3646758/53156631-18f1bf00-35c0-11e9-8836-5cae70b2a6d9.png) The reason is that `import { Orientation } ...` is out of the namespace declaration, [which trigger the module declaration in augmentation mode](http://ideasintosoftware.com/typescript-module-augmentation-vs-declaration/). Also, I'm not sure what this first line is supposed to do.
2. `export = Orientation` is inaccurate, as you are using ecmascript module `default` export. `export = Orientation` should have been used [while implementing CommonJS object export](https://nodejs.org/api/modules.html#modules_module_exports). Only by coincidence, Typescript consumers using [`allowSyntheticDefaultImports`](https://www.typescriptlang.org/docs/handbook/compiler-options.html) will not encounter any error, but others will.
3. `Orientation` is a `class` rather than a `namespace`.
4. In `package.json`, define a `types` property. This is not a fix, but rather a compliance [with Typescript recommendations](https://www.typescriptlang.org/docs/handbook/declaration-files/publishing.html#including-declarations-in-your-npm-package)
> *Also note that if your main declaration file is named index.d.ts and lives at the root of the package (next to index.js) you do not need to mark the "types" property, **though it is advisable to do so**.*
