### PR TITLE
Add RCTOrientation-tvOS Target

### DIFF
--- a/iOS/RCTOrientation.xcodeproj/project.pbxproj
+++ b/iOS/RCTOrientation.xcodeproj/project.pbxproj
@@ -8,10 +8,20 @@
 
 /* Begin PBXBuildFile section */
 		27F5D7F01D0BC955003F92DE /* Orientation.m in Sources */ = {isa = PBXBuildFile; fileRef = 27F5D7EF1D0BC955003F92DE /* Orientation.m */; };
+		B59029A32237E1A400A9DA7D /* Orientation.m in Sources */ = {isa = PBXBuildFile; fileRef = 27F5D7EF1D0BC955003F92DE /* Orientation.m */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXCopyFilesBuildPhase section */
 		58B511D91A9E6C8500147676 /* CopyFiles */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "include/$(PRODUCT_NAME)";
+			dstSubfolderSpec = 16;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		B59029A52237E1A400A9DA7D /* CopyFiles */ = {
 			isa = PBXCopyFilesBuildPhase;
 			buildActionMask = 2147483647;
 			dstPath = "include/$(PRODUCT_NAME)";
@@ -26,10 +36,18 @@
 		134814201AA4EA6300B7C361 /* libRCTOrientation.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libRCTOrientation.a; sourceTree = BUILT_PRODUCTS_DIR; };
 		27F5D7EE1D0BC955003F92DE /* Orientation.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Orientation.h; sourceTree = "<group>"; };
 		27F5D7EF1D0BC955003F92DE /* Orientation.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = Orientation.m; sourceTree = "<group>"; };
+		B59029A92237E1A400A9DA7D /* libRCTOrientation-tvOS.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libRCTOrientation-tvOS.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
 		58B511D81A9E6C8500147676 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		B59029A42237E1A400A9DA7D /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -61,6 +79,7 @@
 			children = (
 				27F5D7ED1D0BC820003F92DE /* RCTOrientation */,
 				134814211AA4EA7D00B7C361 /* Products */,
+				B59029A92237E1A400A9DA7D /* libRCTOrientation-tvOS.a */,
 			);
 			sourceTree = "<group>";
 		};
@@ -82,6 +101,23 @@
 			name = RCTOrientation;
 			productName = RCTDataManager;
 			productReference = 134814201AA4EA6300B7C361 /* libRCTOrientation.a */;
+			productType = "com.apple.product-type.library.static";
+		};
+		B59029A12237E1A400A9DA7D /* RCTOrientation-tvOS */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = B59029A62237E1A400A9DA7D /* Build configuration list for PBXNativeTarget "RCTOrientation-tvOS" */;
+			buildPhases = (
+				B59029A22237E1A400A9DA7D /* Sources */,
+				B59029A42237E1A400A9DA7D /* Frameworks */,
+				B59029A52237E1A400A9DA7D /* CopyFiles */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = "RCTOrientation-tvOS";
+			productName = RCTDataManager;
+			productReference = B59029A92237E1A400A9DA7D /* libRCTOrientation-tvOS.a */;
 			productType = "com.apple.product-type.library.static";
 		};
 /* End PBXNativeTarget section */
@@ -111,6 +147,7 @@
 			projectRoot = "";
 			targets = (
 				58B511DA1A9E6C8500147676 /* RCTOrientation */,
+				B59029A12237E1A400A9DA7D /* RCTOrientation-tvOS */,
 			);
 		};
 /* End PBXProject section */
@@ -121,6 +158,14 @@
 			buildActionMask = 2147483647;
 			files = (
 				27F5D7F01D0BC955003F92DE /* Orientation.m in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		B59029A22237E1A400A9DA7D /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				B59029A32237E1A400A9DA7D /* Orientation.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -252,6 +297,40 @@
 			};
 			name = Release;
 		};
+		B59029A72237E1A400A9DA7D /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				HEADER_SEARCH_PATHS = (
+					"$(inherited)",
+					/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include,
+					"$(SRCROOT)/../../React/**",
+					"$(SRCROOT)/../../react-native/React/**",
+				);
+				LIBRARY_SEARCH_PATHS = "$(inherited)";
+				OTHER_LDFLAGS = "-ObjC";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SKIP_INSTALL = YES;
+				SUPPORTED_PLATFORMS = "appletvsimulator appletvos";
+			};
+			name = Debug;
+		};
+		B59029A82237E1A400A9DA7D /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				HEADER_SEARCH_PATHS = (
+					"$(inherited)",
+					/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include,
+					"$(SRCROOT)/../../React/**",
+					"$(SRCROOT)/../../react-native/React/**",
+				);
+				LIBRARY_SEARCH_PATHS = "$(inherited)";
+				OTHER_LDFLAGS = "-ObjC";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SKIP_INSTALL = YES;
+				SUPPORTED_PLATFORMS = "appletvsimulator appletvos";
+			};
+			name = Release;
+		};
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
@@ -269,6 +348,15 @@
 			buildConfigurations = (
 				58B511F01A9E6C8500147676 /* Debug */,
 				58B511F11A9E6C8500147676 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		B59029A62237E1A400A9DA7D /* Build configuration list for PBXNativeTarget "RCTOrientation-tvOS" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				B59029A72237E1A400A9DA7D /* Debug */,
+				B59029A82237E1A400A9DA7D /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/iOS/RCTOrientation/Orientation.h
+++ b/iOS/RCTOrientation/Orientation.h
@@ -13,6 +13,8 @@
 #import <React/RCTEventEmitter.h>
 
 @interface Orientation : RCTEventEmitter <RCTBridgeModule>
+#if (!TARGET_OS_TV)
 + (void)setOrientation: (UIInterfaceOrientationMask)orientation;
 + (UIInterfaceOrientationMask)getOrientation;
+#endif
 @end

--- a/iOS/RCTOrientation/Orientation.m
+++ b/iOS/RCTOrientation/Orientation.m
@@ -12,11 +12,14 @@
 
 @implementation Orientation
 {
+    #if (!TARGET_OS_TV)
     UIInterfaceOrientation _lastOrientation;
     UIInterfaceOrientation _lastDeviceOrientation;
+    #endif
     BOOL _isLocking;
 }
 
+#if (!TARGET_OS_TV)
 static UIInterfaceOrientationMask _orientation = UIInterfaceOrientationMaskAll;
 
 + (void)setOrientation: (UIInterfaceOrientationMask)orientation {
@@ -116,34 +119,44 @@ static UIInterfaceOrientationMask _orientation = UIInterfaceOrientationMaskAll;
     return orientationStr;
     
 }
+#else
+
+- (NSArray<NSString *> *)supportedEvents
+{
+    
+    return @[];
+    
+}
+
+#endif
 
 RCT_EXPORT_MODULE();
 
 RCT_EXPORT_METHOD(getOrientation:(RCTResponseSenderBlock)callback)
 {
-    
+    #if (!TARGET_OS_TV)
     [[NSOperationQueue mainQueue] addOperationWithBlock:^ {
         UIInterfaceOrientation orientation = [UIApplication sharedApplication].statusBarOrientation;
         NSString *orientationStr = [self getOrientationStr:orientation];
         callback(@[orientationStr]);
     }];
-    
+    #endif
 }
 
 RCT_EXPORT_METHOD(getDeviceOrientation:(RCTResponseSenderBlock)callback)
 {
-    
+    #if (!TARGET_OS_TV)
     [[NSOperationQueue mainQueue] addOperationWithBlock:^ {
         UIInterfaceOrientation deviceOrientation = (UIInterfaceOrientation) [UIDevice currentDevice].orientation;
         NSString *orientationStr = [self getOrientationStr:deviceOrientation];
         callback(@[orientationStr]);
     }];
-    
+    #endif
 }
 
 RCT_EXPORT_METHOD(lockToPortrait)
 {
-
+    #if (!TARGET_OS_TV)
     [[NSOperationQueue mainQueue] addOperationWithBlock:^ {
         
         // set a flag so that no deviceOrientationDidChange events are sent to JS
@@ -169,7 +182,7 @@ RCT_EXPORT_METHOD(lockToPortrait)
         _isLocking = NO;
         
     }];
-    
+    #endif
 }
 
 RCT_EXPORT_METHOD(lockToLandscape)
@@ -179,6 +192,7 @@ RCT_EXPORT_METHOD(lockToLandscape)
     NSLog(@"Locked to Landscape");
 #endif
 
+    #if (!TARGET_OS_TV)
     [[NSOperationQueue mainQueue] addOperationWithBlock:^ {
         
         // set a flag so that no deviceOrientationDidChange events are sent to JS
@@ -211,7 +225,7 @@ RCT_EXPORT_METHOD(lockToLandscape)
         _isLocking = NO;
         
     }];
-    
+    #endif
 }
 
 RCT_EXPORT_METHOD(lockToLandscapeRight)
@@ -221,6 +235,7 @@ RCT_EXPORT_METHOD(lockToLandscapeRight)
     NSLog(@"Locked to Landscape Right");
 #endif
     
+    #if (!TARGET_OS_TV)
     [[NSOperationQueue mainQueue] addOperationWithBlock:^ {
         
         // set a flag so that no deviceOrientationDidChange events are sent to JS
@@ -246,7 +261,7 @@ RCT_EXPORT_METHOD(lockToLandscapeRight)
         _isLocking = NO;
         
     }];
-    
+    #endif
 }
 
 RCT_EXPORT_METHOD(lockToLandscapeLeft)
@@ -255,7 +270,7 @@ RCT_EXPORT_METHOD(lockToLandscapeLeft)
 #if DEBUG
     NSLog(@"Locked to Landscape Left");
 #endif
-    
+    #if (!TARGET_OS_TV)
     [[NSOperationQueue mainQueue] addOperationWithBlock:^ {
 
         // set a flag so that no deviceOrientationDidChange events are sent to JS
@@ -281,6 +296,7 @@ RCT_EXPORT_METHOD(lockToLandscapeLeft)
         _isLocking = NO;
         
     }];
+    #endif
     
 }
 
@@ -291,6 +307,7 @@ RCT_EXPORT_METHOD(unlockAllOrientations)
     NSLog(@"Unlock All Orientations");
 #endif
     
+    #if (!TARGET_OS_TV)
     [[NSOperationQueue mainQueue] addOperationWithBlock:^ {
         
         // set a flag so that no deviceOrientationDidChange events are sent to JS
@@ -312,17 +329,19 @@ RCT_EXPORT_METHOD(unlockAllOrientations)
         _isLocking = NO;
 
     }];
-
+    #endif
 }
 
 - (NSDictionary *)constantsToExport
 {
     
+    #if (!TARGET_OS_TV)
     UIInterfaceOrientation orientation = [UIApplication sharedApplication].statusBarOrientation;
     NSString *orientationStr = [self getOrientationStr:orientation];
     
     return @{@"initialOrientation": orientationStr};
-    
+    #endif
+    return nil;
 }
 
 + (BOOL)requiresMainQueueSetup


### PR DESCRIPTION
We are using this library in a project that also has an Apple TV app. The problem is that this project doesn't have a tvOS target because it does not make sense to listen for Orientation on an Apple TV.

But the problem is that our shared code can't work if there is no target. I added a target to mock the bridge. So it compiles on tvOS but nothing actually happens. 