### PR TITLE
Catch unknown device orientation value

### DIFF
--- a/android/src/main/java/org/wonday/orientation/OrientationModule.java
+++ b/android/src/main/java/org/wonday/orientation/OrientationModule.java
@@ -63,7 +63,9 @@ public class OrientationModule extends ReactContextBaseJavaModule implements Lif
                 String deviceOrientationValue = lastDeviceOrientationValue;
 
 
-                if (orientation > 355 || orientation < 5) {
+                if (orientation == -1) {
+                    deviceOrientationValue = "UNKNOWN";
+                } else if (orientation > 355 || orientation < 5) {
                     deviceOrientationValue = "PORTRAIT";
                 } else if (orientation > 85 && orientation < 95) {
                     deviceOrientationValue = "LANDSCAPE-RIGHT";


### PR DESCRIPTION
Orientation is -1 when the device is close to flat, which prematurely sets deviceOrientationValue to portrait. 

This causes conditions like `if (orientation == 'PORTRAIT')` to trigger too early.