### PR TITLE
Add FaceDown Orientation value

### DIFF
--- a/android/src/main/java/org/wonday/orientation/OrientationModule.java
+++ b/android/src/main/java/org/wonday/orientation/OrientationModule.java
@@ -61,9 +61,10 @@ public class OrientationModule extends ReactContextBaseJavaModule implements Lif
                 FLog.d(ReactConstants.TAG,"DeviceOrientation changed to " + orientation);
 
                 String deviceOrientationValue = lastDeviceOrientationValue;
-
-
-                if (orientation > 355 || orientation < 5) {
+                
+                if (orientation == -1) {
+                    deviceOrientationValue = "FACE-DOWN";
+                } else if (orientation > 355 || orientation < 5) {
                     deviceOrientationValue = "PORTRAIT";
                 } else if (orientation > 85 && orientation < 95) {
                     deviceOrientationValue = "LANDSCAPE-RIGHT";


### PR DESCRIPTION
Currently the device turns automatically when it is on a flat surface, when this happens the orientation is `-1` and this verifies that the device is ***face down***.

✅ Tested on Huawei PRA-LX3 - OS Android 8.

Refs: 

https://developer.android.com/reference/android/R.attr.html#screenOrientation
https://developer.android.com/reference/android/view/Surface
https://developer.android.com/reference/android/content/pm/ActivityInfo