### PR TITLE
Convert OrientationType to enum

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -6,7 +6,13 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-export type OrientationType = "PORTRAIT" | "PORTRAIT-UPSIDEDOWN" | "LANDSCAPE-LEFT" | "LANDSCAPE-RIGHT" | "UNKNOWN";
+export enum OrientationType {
+  PORTRAIT = "PORTRAIT",
+  PORTRAIT_UPSIDEDOWN = "PORTRAIT-UPSIDEDOWN",
+  LANDSCAPE_LEFT = "LANDSCAPE-LEFT",
+  LANDSCAPE_RIGHT = "LANDSCAPE-RIGHT",
+  UNKNOWN = "UNKNOWN"
+}
 declare class Orientation {
   static addOrientationListener(callback: (orientation: OrientationType) => void): void;
   static removeOrientationListener(callback: (orientation: OrientationType) => void): void;


### PR DESCRIPTION
Convert OrientationType to enum because it's better to use an enum instead of string in Typescript