### PR TITLE
Add deployment target for tvOS

### DIFF
--- a/react-native-orientation-locker.podspec
+++ b/react-native-orientation-locker.podspec
@@ -13,6 +13,7 @@ Pod::Spec.new do |s|
   s.source         = { :git => 'https://github.com/wonday/react-native-orientation-locker.git', :tag => "v#{s.version}" }
   s.requires_arc   = true
   s.platform       = :ios, '8.0'
+  s.platform       = :tvos, '11.0'
   s.preserve_paths = 'README.md', 'package.json', 'index.js'
   s.source_files   = 'iOS/**/*.{h,m}'
   s.dependency     'React'

--- a/react-native-orientation-locker.podspec
+++ b/react-native-orientation-locker.podspec
@@ -12,8 +12,8 @@ Pod::Spec.new do |s|
   s.homepage       = package['homepage']
   s.source         = { :git => 'https://github.com/wonday/react-native-orientation-locker.git', :tag => "v#{s.version}" }
   s.requires_arc   = true
-  s.platform       = :ios, '8.0'
-  s.platform       = :tvos, '11.0'
+  s.ios.deployment_target = '8.0'
+  s.tvos.deployment_target = '11.0'
   s.preserve_paths = 'README.md', 'package.json', 'index.js'
   s.source_files   = 'iOS/**/*.{h,m}'
   s.dependency     'React'


### PR DESCRIPTION
The current podspec file doesn't have the tvOS deployment target.
This change adds the deployment target support.