### PR TITLE
Adding support for iOS FACE-UP and FACE-DOWN orientations

### DIFF
--- a/README.md
+++ b/README.md
@@ -270,6 +270,8 @@ orientation can return one of:
 - `LANDSCAPE-LEFT` camera left home button right
 - `LANDSCAPE-RIGHT` camera right home button left
 - `PORTRAIT-UPSIDEDOWN`
+- `FACE-UP`
+- `FACE-DOWN`
 - `UNKNOWN`
 
-Notice: PORTRAIT-UPSIDEDOWN is currently not supported on iOS at the moment.
+Notice: PORTRAIT-UPSIDEDOWN is currently not supported on iOS at the moment. FACE-UP and FACE-DOWN are only supported on iOS.

--- a/iOS/RCTOrientation/Orientation.m
+++ b/iOS/RCTOrientation/Orientation.m
@@ -99,7 +99,17 @@ static UIInterfaceOrientationMask _orientationMask = UIInterfaceOrientationMaskA
             
             orientationStr = @"PORTRAIT-UPSIDEDOWN";
             break;
-            
+        
+        case UIDeviceOrientationFaceUp:
+
+            orientationStr = @"FACE-UP";
+            break;
+
+        case UIDeviceOrientationFaceDown:
+        
+            orientationStr = @"FACE-DOWN";
+            break;
+
         default:
             orientationStr = @"UNKNOWN";
             break;

--- a/index.d.ts
+++ b/index.d.ts
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-export type OrientationType = "PORTRAIT" | "PORTRAIT-UPSIDEDOWN" | "LANDSCAPE-LEFT" | "LANDSCAPE-RIGHT" | "UNKNOWN";
+export type OrientationType = "PORTRAIT" | "PORTRAIT-UPSIDEDOWN" | "LANDSCAPE-LEFT" | "LANDSCAPE-RIGHT" | "FACE-UP" | "FACE-DOWN" | "UNKNOWN";
 
 declare class Orientation {
   static addOrientationListener(callback: (orientation: OrientationType) => void): void;


### PR DESCRIPTION
This is possibly a breaking change as the current behavior is to return `UNKNOWN` for `FACE-UP` and `FACE-DOWN` orientations. Currently iOS only.