### PR TITLE
Add support for lockAllOrientationsButUpsideDown

### DIFF
--- a/README.md
+++ b/README.md
@@ -262,6 +262,7 @@ It can return either `PORTRAIT` `LANDSCAPE-LEFT` `LANDSCAPE-RIGHT` `UNKNOWN`
 - `lockToLandscapeLeft()`  this will lock to camera left home button right
 - `lockToLandscapeRight()` this will lock to camera right home button left
 - `lockToPortraitUpsideDown` only support android
+- `lockToAllOrientationsButUpsideDown` only ios
 - `unlockAllOrientations()`
 - `getOrientation(function(orientation))`
 - `getDeviceOrientation(function(deviceOrientation))`

--- a/iOS/RCTOrientation/Orientation.m
+++ b/iOS/RCTOrientation/Orientation.m
@@ -265,7 +265,7 @@ RCT_EXPORT_METHOD(lockToAllOrientationsButUpsideDown)
 #endif
 #if (!TARGET_OS_TV)
     [[NSOperationQueue mainQueue] addOperationWithBlock:^ {
-        [self lockToOrientation:UIInterfaceOrientationMaskAllButUpsideDown usingMask:UIInterfaceOrientationMaskAllButUpsideDown];
+        [self lockToOrientation:UIInterfaceOrientationPortrait usingMask:UIInterfaceOrientationMaskAllButUpsideDown];
     }];
 #endif
 }

--- a/iOS/RCTOrientation/Orientation.m
+++ b/iOS/RCTOrientation/Orientation.m
@@ -265,7 +265,7 @@ RCT_EXPORT_METHOD(lockToAllOrientationsButUpsideDown)
 #endif
 #if (!TARGET_OS_TV)
     [[NSOperationQueue mainQueue] addOperationWithBlock:^ {
-        [self lockToOrientation:UIInterfaceOrientationLandscapeRight usingMask:UIInterfaceOrientationMaskAllButUpsideDown];
+        [self lockToOrientation:UIInterfaceOrientationMaskAllButUpsideDown usingMask:UIInterfaceOrientationMaskAllButUpsideDown];
     }];
 #endif
 }

--- a/iOS/RCTOrientation/Orientation.m
+++ b/iOS/RCTOrientation/Orientation.m
@@ -258,6 +258,18 @@ RCT_EXPORT_METHOD(lockToLandscapeLeft)
 #endif
 }
 
+RCT_EXPORT_METHOD(lockToAllOrientationsButUpsideDown)
+{
+#if DEBUG
+    NSLog(@"Locking to all except upside down");
+#endif
+#if (!TARGET_OS_TV)
+    [[NSOperationQueue mainQueue] addOperationWithBlock:^ {
+        [self lockToOrientation:UIInterfaceOrientationLandscapeRight usingMask:UIInterfaceOrientationMaskAllButUpsideDown];
+    }];
+#endif
+}
+
 RCT_EXPORT_METHOD(unlockAllOrientations)
 {
 #if DEBUG

--- a/index.d.ts
+++ b/index.d.ts
@@ -21,6 +21,7 @@ declare class Orientation {
   static lockToPortrait(): void;
   static lockToLandscape(): void;
   static lockToLandscapeLeft(): void;
+  static lockToAllOrientationsButUpsideDown(): void;
   static lockToLandscapeRight(): void;
   static lockToPortraitUpsideDown(): void;
   static unlockAllOrientations(): void;

--- a/index.js
+++ b/index.js
@@ -74,6 +74,14 @@ export default class Orientation {
         OrientationNative.lockToLandscapeLeft();
     };
 
+    // OrientationMaskAllButUpsideDown
+    static lockToAllOrientationsButUpsideDown = () => {
+        locked = true;
+        if (Platform.OS === "ios") {
+            OrientationNative.lockToAllOrientationsButUpsideDown();
+        }
+    };
+
     static unlockAllOrientations = () => {
         locked = false;
         OrientationNative.unlockAllOrientations();


### PR DESCRIPTION
Add support for UIInterfaceOrientationMaskAllButUpsideDown lock (ios only).
https://developer.apple.com/documentation/uikit/uiinterfaceorientationmask/uiinterfaceorientationmaskallbutupsidedown?language=objc