### PR TITLE
Fix for not finding @ReactModule 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,6 @@ node_modules/
 xcuserdata/
 xcshareddata/
 contents.xcworkspacedata
+android/.gradle
+android/.project
+android/.settings

--- a/android/src/main/java/org/wonday/orientation/OrientationModule.java
+++ b/android/src/main/java/org/wonday/orientation/OrientationModule.java
@@ -15,12 +15,10 @@ import android.content.Context;
 import android.content.Intent;
 import android.content.IntentFilter;
 import android.content.pm.ActivityInfo;
-import android.content.res.Configuration;
 import android.view.OrientationEventListener;
 import android.view.Display;
 import android.view.Surface;
 import android.view.WindowManager;
-import android.util.DisplayMetrics;
 import android.hardware.SensorManager;
 
 import com.facebook.common.logging.FLog;
@@ -30,6 +28,7 @@ import com.facebook.react.bridge.LifecycleEventListener;
 import com.facebook.react.bridge.ReactApplicationContext;
 import com.facebook.react.bridge.ReactContextBaseJavaModule;
 import com.facebook.react.bridge.ReactMethod;
+import com.facebook.react.module.annotations.ReactModule;
 import com.facebook.react.bridge.WritableMap;
 import com.facebook.react.common.ReactConstants;
 import com.facebook.react.modules.core.DeviceEventManagerModule;
@@ -39,6 +38,7 @@ import java.util.Map;
 
 import javax.annotation.Nullable;
 
+@ReactModule(name = "OrientationModule")
 public class OrientationModule extends ReactContextBaseJavaModule implements LifecycleEventListener{
 
     final BroadcastReceiver mReceiver;

--- a/android/src/main/java/org/wonday/orientation/OrientationModule.java
+++ b/android/src/main/java/org/wonday/orientation/OrientationModule.java
@@ -38,7 +38,7 @@ import java.util.Map;
 
 import javax.annotation.Nullable;
 
-@ReactModule(name = "OrientationModule")
+@ReactModule(name = "Orientation")
 public class OrientationModule extends ReactContextBaseJavaModule implements LifecycleEventListener{
 
     final BroadcastReceiver mReceiver;


### PR DESCRIPTION
Since RN 0.58 we need to add @ReactModule annotation for accessing the module natively:

> Native Modules in Android now require @ReactModule annotations to access .getNativeModule method on the ReactContext

https://github.com/react-native-community/releases/blob/master/CHANGELOG.md#breaking-changes-

This PR adds the annotation. I've also removed some unused imports and added some gitignore rules for Android. Thanks for the awesome library