### PR TITLE
[Android] implement ActivityLifecycleCallbacks

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,7 +153,7 @@ Add following to MainApplication.java
 ```diff
 //...
 +import org.wonday.orientation.OrientationPackage;
-
++import org.wonday.orientation.OrientationActivityLifecycle;
     @Override
     protected List<ReactPackage> getPackages() {
       @SuppressWarnings("UnnecessaryLocalVariable")
@@ -164,6 +164,12 @@ Add following to MainApplication.java
       return packages;
     }
 //...
+
+  @Override
+  public void onCreate() {
+    ...
++    registerActivityLifecycleCallbacks(OrientationActivityLifecycle.getInstance());
+  }
 ```
 
 ## Usage

--- a/android/src/main/java/org/wonday/orientation/OrientationActivityLifecycle.java
+++ b/android/src/main/java/org/wonday/orientation/OrientationActivityLifecycle.java
@@ -1,0 +1,83 @@
+package org.wonday.orientation;
+
+import android.app.Activity;
+import android.app.Application;
+import android.os.Bundle;
+import android.util.Log;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+public class OrientationActivityLifecycle implements Application.ActivityLifecycleCallbacks {
+    private static final String TAG = "OrientationModule";
+    private static AtomicInteger activeCount = new AtomicInteger(0);
+    private OrientationListeners orientationListeners;
+
+    private static OrientationActivityLifecycle instance;
+
+    public static OrientationActivityLifecycle getInstance() {
+        if (instance == null) {
+            instance = new OrientationActivityLifecycle();
+        }
+        return instance;
+    }
+
+    private OrientationActivityLifecycle() {}
+
+    public void registerListeners(OrientationListeners listener) {
+        this.orientationListeners = listener;
+        if (activeCount.get() == 1) {
+            // Trigger start event
+            orientationListeners.start();
+        }
+    }
+
+    @Override
+    public void onActivityCreated(Activity activity, Bundle savedInstanceState) {
+        Log.d(TAG, "onActivityCreated");
+    }
+
+    @Override
+    public void onActivityStarted(Activity activity) {
+        Log.d(TAG, "onActivityStarted");
+    }
+
+    @Override
+    public void onActivityResumed(Activity activity) {
+        Log.d(TAG, "onActivityResumed");
+        if (activeCount.incrementAndGet() == 1) {
+            if (orientationListeners != null) {
+                Log.d(TAG, "Start orientation");
+                orientationListeners.start();
+            }
+        }
+    }
+
+    @Override
+    public void onActivityPaused(Activity activity) {
+        Log.d(TAG, "onActivityPaused");
+    }
+
+    @Override
+    public void onActivityStopped(Activity activity) {
+        Log.d(TAG, "onActivityStopped");
+        if (activeCount.decrementAndGet() == 0) {
+            if (orientationListeners != null) {
+                orientationListeners.stop();
+            }
+        }
+
+    }
+
+    @Override
+    public void onActivitySaveInstanceState(Activity activity, Bundle outState) {
+        Log.d(TAG, "onActivitySaveInstanceState");
+    }
+
+    @Override
+    public void onActivityDestroyed(Activity activity) {
+        Log.d(TAG, "onActivityDestroyed");
+        if (activeCount.get() == 0) {
+            orientationListeners.release();
+        }
+    }
+}

--- a/android/src/main/java/org/wonday/orientation/OrientationActivityLifecycle.java
+++ b/android/src/main/java/org/wonday/orientation/OrientationActivityLifecycle.java
@@ -77,7 +77,9 @@ public class OrientationActivityLifecycle implements Application.ActivityLifecyc
     public void onActivityDestroyed(Activity activity) {
         Log.d(TAG, "onActivityDestroyed");
         if (activeCount.get() == 0) {
-            orientationListeners.release();
+            if (orientationListeners != null) {
+                orientationListeners.release();
+            }
         }
     }
 }

--- a/android/src/main/java/org/wonday/orientation/OrientationListeners.java
+++ b/android/src/main/java/org/wonday/orientation/OrientationListeners.java
@@ -1,0 +1,9 @@
+package org.wonday.orientation;
+
+interface OrientationListeners {
+    void start();
+
+    void stop();
+
+    void release();
+}

--- a/android/src/main/java/org/wonday/orientation/OrientationModule.java
+++ b/android/src/main/java/org/wonday/orientation/OrientationModule.java
@@ -15,11 +15,11 @@ import android.content.Context;
 import android.content.Intent;
 import android.content.IntentFilter;
 import android.content.pm.ActivityInfo;
-import android.view.OrientationEventListener;
+import android.hardware.SensorManager;
 import android.view.Display;
+import android.view.OrientationEventListener;
 import android.view.Surface;
 import android.view.WindowManager;
-import android.hardware.SensorManager;
 
 import com.facebook.common.logging.FLog;
 import com.facebook.react.bridge.Arguments;
@@ -28,7 +28,6 @@ import com.facebook.react.bridge.LifecycleEventListener;
 import com.facebook.react.bridge.ReactApplicationContext;
 import com.facebook.react.bridge.ReactContextBaseJavaModule;
 import com.facebook.react.bridge.ReactMethod;
-import com.facebook.react.module.annotations.ReactModule;
 import com.facebook.react.bridge.WritableMap;
 import com.facebook.react.common.ReactConstants;
 import com.facebook.react.modules.core.DeviceEventManagerModule;
@@ -38,8 +37,7 @@ import java.util.Map;
 
 import javax.annotation.Nullable;
 
-@ReactModule(name = "Orientation")
-public class OrientationModule extends ReactContextBaseJavaModule implements LifecycleEventListener{
+public class OrientationModule extends ReactContextBaseJavaModule implements OrientationListeners {
 
     final BroadcastReceiver mReceiver;
     final OrientationEventListener mOrientationListener;
@@ -47,7 +45,6 @@ public class OrientationModule extends ReactContextBaseJavaModule implements Lif
     private boolean isLocked = false;
     private String lastOrientationValue = "";
     private String lastDeviceOrientationValue = "";
-
 
     public OrientationModule(ReactApplicationContext reactContext) {
         super(reactContext);
@@ -119,8 +116,7 @@ public class OrientationModule extends ReactContextBaseJavaModule implements Lif
 
             }
         };
-
-        ctx.addLifecycleEventListener(this);
+        OrientationActivityLifecycle.getInstance().registerListeners(this);
     }
 
     @Override
@@ -339,7 +335,7 @@ public class OrientationModule extends ReactContextBaseJavaModule implements Lif
     }
 
     @Override
-    public void onHostResume() {
+    public void start() {
         FLog.i(ReactConstants.TAG, "orientation detect enabled.");
         mOrientationListener.enable();
 
@@ -347,8 +343,9 @@ public class OrientationModule extends ReactContextBaseJavaModule implements Lif
         if (activity == null) return;
         activity.registerReceiver(mReceiver, new IntentFilter("onConfigurationChanged"));
     }
+
     @Override
-    public void onHostPause() {
+    public void stop() {
         FLog.d(ReactConstants.TAG, "orientation detect disabled.");
         mOrientationListener.disable();
 
@@ -364,7 +361,7 @@ public class OrientationModule extends ReactContextBaseJavaModule implements Lif
     }
 
     @Override
-    public void onHostDestroy() {
+    public void release() {
         FLog.d(ReactConstants.TAG, "orientation detect disabled.");
         mOrientationListener.disable();
 


### PR DESCRIPTION
Hi, I got problem when starting new Activity, the orientation event stop sending.
This PR implement `ActivityLifecycleCallbacks` and check for current active activity. If there is no active activity in `onActivityStopped`, then pause the orientation listener.

## BREAKING CHANGES:
Need to add to `onCreate` of ` MyApplication.java`
```
registerActivityLifecycleCallbacks(OrientationActivityLifecycle.getInstance());
```