### PR TITLE
Fix unlockAllOrientations on Android

### DIFF
--- a/android/src/main/java/org/wonday/orientation/OrientationModule.java
+++ b/android/src/main/java/org/wonday/orientation/OrientationModule.java
@@ -296,7 +296,7 @@ public class OrientationModule extends ReactContextBaseJavaModule implements Lif
 
         final Activity activity = getCurrentActivity();
         if (activity == null) return;
-        activity.setRequestedOrientation(ActivityInfo.SCREEN_ORIENTATION_UNSPECIFIED);
+        activity.setRequestedOrientation(ActivityInfo.SCREEN_ORIENTATION_SENSOR);
         isLocked = false;
 
         //force send an UI orientation event when unlock


### PR DESCRIPTION
This fixes https://github.com/wonday/react-native-orientation-locker/issues/114 & https://github.com/wonday/react-native-orientation-locker/issues/97