### PR TITLE
fix: Xcode 12 compatibility

### DIFF
--- a/react-native-orientation-locker.podspec
+++ b/react-native-orientation-locker.podspec
@@ -16,5 +16,5 @@ Pod::Spec.new do |s|
   s.tvos.deployment_target = '11.0'
   s.preserve_paths = 'README.md', 'package.json', 'index.js'
   s.source_files   = 'iOS/**/*.{h,m}'
-  s.dependency     'React'
+  s.dependency     'React-Core'
 end


### PR DESCRIPTION
Latest Xcode 12 fails to build while without a module to depend on React-Core directly hence this change is necessary for all native modules on iOS. For more details please check: facebook/react-native#29633 (comment)