### PR TITLE
Export <OrientationLocker>

### DIFF
--- a/README.md
+++ b/README.md
@@ -253,7 +253,7 @@ import Orientation from 'react-native-orientation-locker';
 
 ### Reactive component `<OrientationLocker>`
 
-It is possible to have multiple `OrientationLocker` components mounted at the same time. The props will be merged in the order the `OrientationLocker` components were mounted. This follows the usability of (StatusBar)[https://reactnative.dev/docs/statusbar].
+It is possible to have multiple `OrientationLocker` components mounted at the same time. The props will be merged in the order the `OrientationLocker` components were mounted. This follows the same usability of [\<StatusBar\>](https://reactnative.dev/docs/statusbar).
 
 ```js
 import React, { useState } from "react";

--- a/README.md
+++ b/README.md
@@ -251,20 +251,20 @@ import Orientation from 'react-native-orientation-locker';
   }
 ```
 
-### Reactive component `<ScreenOrientation>`
+### Reactive component `<OrientationLocker>`
 
-It is possible to have multiple `ScreenOrientation` components mounted at the same time. The props will be merged in the order the `ScreenOrientation` components were mounted.
+It is possible to have multiple `OrientationLocker` components mounted at the same time. The props will be merged in the order the `OrientationLocker` components were mounted. This follows the usability of (StatusBar)[https://reactnative.dev/docs/statusbar].
 
 ```js
 import React, { useState } from "react";
 import { Text, View } from "react-native";
-import ScreenOrientation, { PORTRAIT, LANDSCAPE } from "react-native-orientation-locker/ScreenOrientation";
+import { OrientationLocker, PORTRAIT, LANDSCAPE } from "react-native-orientation-locker";
 
 export default function App() {
   const [showVideo, setShowVideo] = useState(true);
   return (
     <View style={{ flex: 1, justifyContent: 'center', alignItems: 'center' }}>
-      <ScreenOrientation
+      <OrientationLocker
         orientation={PORTRAIT}
         onChange={orientation => console.log('onChange', orientation)}
         onDeviceChange={orientation => console.log('onDeviceChange', orientation)}
@@ -272,7 +272,7 @@ export default function App() {
       <Button title="Toggle Video" onPress={() => setShowVideo(!showVideo)} />
       {showVideo && (
         <View>
-          <ScreenOrientation orientation={LANDSCAPE} />
+          <OrientationLocker orientation={LANDSCAPE} />
           <View style={{ width: 320, height: 180, backgroundColor: '#ccc' }}>
             <Text>Landscape video goes here</Text>
           </View>

--- a/index.js
+++ b/index.js
@@ -11,5 +11,6 @@
 import Orientation from './src/orientation';
 
 export * from './src/hooks';
+export * from './src/OrientationLocker';
 
 export default Orientation;

--- a/src/OrientationLocker.js
+++ b/src/OrientationLocker.js
@@ -48,7 +48,7 @@ function update() {
   });
 }
 
-export default function OrientationLocker({
+export function OrientationLocker({
   orientation,
   onChange,
   onDeviceChange,

--- a/src/OrientationLocker.js
+++ b/src/OrientationLocker.js
@@ -48,7 +48,7 @@ function update() {
   });
 }
 
-export default function ScreenOrientation({
+export default function OrientationLocker({
   orientation,
   onChange,
   onDeviceChange,


### PR DESCRIPTION
1. Rename the `ScreenOrientation` to `OrientationLocker`, so it's more similar with repository name.
2. It's also export the component like the hooks.

ref: https://github.com/wonday/react-native-orientation-locker/pull/116