### PR TITLE
Updates OrienetationType Tyescript Type to Enum

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -6,7 +6,15 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-export type OrientationType = "PORTRAIT" | "PORTRAIT-UPSIDEDOWN" | "LANDSCAPE-LEFT" | "LANDSCAPE-RIGHT" | "FACE-UP" | "FACE-DOWN" | "UNKNOWN";
+export enum OrientationType {
+  "PORTRAIT" = "PORTRAIT",
+  "PORTRAIT-UPSIDEDOWN" = "PORTRAIT-UPSIDEDOWN",
+  "LANDSCAPE-LEFT" = "LANDSCAPE-LEFT",
+  "LANDSCAPE-RIGHT" = "LANDSCAPE-RIGHT",
+  "FACE-UP" = "FACE-UP",
+  "FACE-DOWN" = "FACE-DOWN",
+  "UNKNOWN" = "UNKNOWN",
+}
 
 declare class Orientation {
   static addOrientationListener(callback: (orientation: OrientationType) => void): void;


### PR DESCRIPTION
Currently OrienetationType is a Typescript Type, and can be used to denote it's expected string values for variable and argument assignments. However, it is not able to be used to assign values or for value comparisons.

For example:

Current
```
function (deviceOrientation: OrientationType) {
  if (deviceOrientation === 'PORTRAIT') {
    // do something
  }
}
```

Updated
```
function (deviceOrientation: OrientationType) {
  if (deviceOrientation === OrientationType.PORTRAIT) {
    // do something
  }
}
```