### PR TITLE
fix: add stub methods to remove warning while using listeners

### DIFF
--- a/android/src/main/java/org/wonday/orientation/OrientationModule.java
+++ b/android/src/main/java/org/wonday/orientation/OrientationModule.java
@@ -367,4 +367,14 @@ public class OrientationModule extends ReactContextBaseJavaModule implements Ori
             FLog.w(ReactConstants.TAG, "Receiver already unregistered", e);
         }
     }
+
+    @ReactMethod
+    public void addListener(String eventName) {
+     // Keep: Required for RN built in Event Emitter Calls.
+    }
+
+    @ReactMethod
+    public void removeListeners(Integer count) {
+     // Keep: Required for RN built in Event Emitter Calls.
+    }
 }


### PR DESCRIPTION
This PR is a fix related to this comment : https://github.com/wonday/react-native-orientation-locker/pull/202#issuecomment-995385015

In fact there is a warning left : new NativeEventEmitter()' was called with a non-null argument without the required 'removeListeners' 

Solution is inspired from https://github.com/software-mansion/react-native-reanimated/pull/2316