### PR TITLE
Remove unnecessary restoration of Orientation

### DIFF
--- a/iOS/RCTOrientation/Orientation.m
+++ b/iOS/RCTOrientation/Orientation.m
@@ -130,9 +130,6 @@ static UIInterfaceOrientationMask _orientationMask = UIInterfaceOrientationMaskA
     [currentDevice setValue:@(UIInterfaceOrientationUnknown) forKey:orientation];
     [currentDevice setValue:@(newOrientation) forKey:orientation];
     
-    // restore device orientation
-    [currentDevice setValue:@(deviceOrientation) forKey:orientation];
-    
     [UIViewController attemptRotationToDeviceOrientation];
     
     [self sendEventWithName:@"lockDidChange" body:@{orientation: [self getOrientationStr:newOrientation]}];


### PR DESCRIPTION
I found that this was creating unnecessary rotations on iOS and a delayed 
lockToLandscape as is described in 
https://github.com/wonday/react-native-orientation-locker/issues/210
