### PR TITLE
Add VS2022 support and misc

### DIFF
--- a/windows/OrientationWindows/OrientationWindows.cpp
+++ b/windows/OrientationWindows/OrientationWindows.cpp
@@ -16,6 +16,16 @@ namespace OrientationWindows {
         }
     }
 
+    void OrientationLockerModule::addListener(std::string) noexcept
+    {
+        // Keep: Required for RN built in Event Emitter Calls.
+    }
+
+    void OrientationLockerModule::removeListeners(int64_t) noexcept
+    {
+        // Keep: Required for RN built in Event Emitter Calls.
+    }
+
     void OrientationLockerModule::GetOrientation(std::function<void(std::string)> cb) noexcept {
         m_context.UIDispatcher().Post([weakThis = weak_from_this(), this, cb]() {
             if (auto strongThis = weakThis.lock())

--- a/windows/OrientationWindows/OrientationWindows.h
+++ b/windows/OrientationWindows/OrientationWindows.h
@@ -15,6 +15,14 @@ namespace OrientationWindows {
         REACT_INIT(Initialize)
         void Initialize(React::ReactContext const& reactContext) noexcept;
 
+        // Only used to suppress some warnings. Not actually used at this time.
+        REACT_METHOD(addListener);
+        void addListener(std::string) noexcept;
+
+        // Only used to suppress some warnings. Not actually used at this time.
+        REACT_METHOD(removeListeners);
+        void removeListeners(int64_t) noexcept;
+    
         REACT_METHOD(GetOrientation, L"getOrientation");
         void GetOrientation(std::function<void(std::string)> cb) noexcept;
 

--- a/windows/OrientationWindows/OrientationWindows.vcxproj
+++ b/windows/OrientationWindows/OrientationWindows.vcxproj
@@ -60,6 +60,7 @@
     <PlatformToolset>v140</PlatformToolset>
     <PlatformToolset Condition="'$(VisualStudioVersion)' == '15.0'">v141</PlatformToolset>
     <PlatformToolset Condition="'$(VisualStudioVersion)' == '16.0'">v142</PlatformToolset>
+    <PlatformToolset Condition="'$(VisualStudioVersion)' == '17.0'">v143</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
     <GenerateManifest>false</GenerateManifest>
   </PropertyGroup>
@@ -154,11 +155,6 @@
   </ItemGroup>
   <ItemGroup>
     <Midl Include="ReactPackageProvider.idl" />
-  </ItemGroup>
-  <ItemGroup>
-    <ProjectReference Include="$(ReactNativeWindowsDir)\Microsoft.ReactNative\Microsoft.ReactNative.vcxproj">
-      <Project>{f7d32bd0-2749-483e-9a0d-1635ef7e3136}</Project>
-    </ProjectReference>
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <!--Here-->


### PR DESCRIPTION
* Add VS2022 support
* Suppress AddLogListener NativeEventListener warnings.  
    *  "Warning: `new NativeEventEmitter()` was called with a non-null argument without the required `addListener` method.  
    *  Also warning for removeListeners method
* Remove unnecessary reference dependency
