### PR TITLE
feat: allows the consumer to disable face up/down detection on ios

### DIFF
--- a/README.md
+++ b/README.md
@@ -362,6 +362,7 @@ It can return either `PORTRAIT` `LANDSCAPE-LEFT` `LANDSCAPE-RIGHT` `UNKNOWN`
 
 ## Functions
 
+- `configure({ disableFaceUpDown: boolean })` (ios only)
 - `lockToPortrait()`
 - `lockToLandscape()`
 - `lockToLandscapeLeft()`  this will lock to camera left home button right

--- a/index.d.ts
+++ b/index.d.ts
@@ -32,9 +32,15 @@ export interface OrientationLockerProps {
   onDeviceChange?: (deviceOrientation: OrientationType) => void;
 }
 
+type IOSConfigurationOptions = {
+  disableFaceUpDown: boolean;
+}
+
 export const OrientationLocker: React.ComponentType<OrientationLockerProps>;
 
 declare class Orientation {
+  static configure(options: IOSConfigurationOptions): void;
+
   static addOrientationListener(callback: (orientation: OrientationType) => void): void;
 
   static removeOrientationListener(callback: (orientation: OrientationType) => void): void;

--- a/src/orientation.android.js
+++ b/src/orientation.android.js
@@ -31,6 +31,10 @@ function getKey(listener) {
 }
 
 export default class Orientation {
+  static configure = (_options) => {
+    // ios only
+  };
+
   static getOrientation = (cb) => {
     OrientationNative.getOrientation((orientation) => {
       cb(orientation);

--- a/src/orientation.ios.js
+++ b/src/orientation.ios.js
@@ -31,6 +31,10 @@ function getKey(listener) {
 }
 
 export default class Orientation {
+  static configure = (options) => {
+    OrientationNative.configure(options);
+  };
+
   static getOrientation = cb => {
     OrientationNative.getOrientation(orientation => {
       cb(orientation);

--- a/src/orientation.js
+++ b/src/orientation.js
@@ -9,6 +9,8 @@
 "use strict";
 
 export default class Orientation {
+  static configure = options => {}
+
   static getOrientation = cb => {
     cb("UNKNOWN");
   };

--- a/src/orientation.windows.js
+++ b/src/orientation.windows.js
@@ -23,6 +23,10 @@ function getKey(listener) {
 }
 
 export default class Orientation {
+    static configure = (_options) => {
+      // ios only
+    };
+
     static getOrientation = cb => {
         OrientationNative.getOrientation(orientation => {
             cb(orientation);


### PR DESCRIPTION
iOS implements the face up and down detection, but a common requirement is to get to know the portrait or landscape status regardless of the facing direction of the device.
This merge request adds the possibility to ignore the facing of the device by calling a configuration function, which should be called as soon as possible and before any other orientation call (ie. in your index.js of App.js).

**Usage**
```ts
Orientation.configure({ disableFaceUpDown: true })
```

Under the hood, it relies on the status bar orientation whenever a face up/down is detected.

Please note that `[UIApplication sharedApplication].statusBarOrientation` has been deprecated since iOS 13, but checking against the device width being greater that its height would loose the information about it being in landscape right or landscape left