### PR TITLE
Functions in the index.d.ts need to declare return types

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -82,11 +82,11 @@ declare class Orientation {
 
 export default Orientation;
 
-declare function useOrientationChange(listener: (orientation: OrientationType) => void);
+declare function useOrientationChange(listener: (orientation: OrientationType) => void): void;
 
-declare function useDeviceOrientationChange(listener: (orientation: OrientationType) => void);
+declare function useDeviceOrientationChange(listener: (orientation: OrientationType) => void): void;
 
-declare function useLockListener(listener: (orientation: OrientationType) => void);
+declare function useLockListener(listener: (orientation: OrientationType) => void): void;
 
 export {
   useOrientationChange,


### PR DESCRIPTION
Otherwise Typescript will complain that they're assumed to be any