### PR TITLE
fix: correctly parses the facing configuration option

### DIFF
--- a/iOS/RCTOrientation/Orientation.m
+++ b/iOS/RCTOrientation/Orientation.m
@@ -168,7 +168,8 @@ RCT_EXPORT_METHOD(configure:(NSDictionary *)options)
 #endif
     
 #if (!TARGET_OS_TV)
-    _disableFaceUpDown = [options objectForKey:@"disableFaceUpDown"] != nil;
+    NSNumber *disableFaceUpDown = [options objectForKey:@"disableFaceUpDown"];
+    _disableFaceUpDown = [disableFaceUpDown boolValue];
 #endif
 }
 


### PR DESCRIPTION
Currently, when the configuration is `disableFaceUpDown: false`, the facing is incorrectly disabled.
This is due to the fact that natively the check is done simply by checking the existence of the key in the dictionary like so:
```objc
_disableFaceUpDown = [options objectForKey:@"disableFaceUpDown"] != nil;
```

This change will correctly parse the boolean option
```objc
NSNumber *disableFaceUpDown = [options objectForKey:@"disableFaceUpDown"];
_disableFaceUpDown = [disableFaceUpDown boolValue];
```