### PR TITLE
Add RECEIVER_EXPORTED/RECEIVER_NOT_EXPORTED to support Android 14

### DIFF
--- a/android/src/main/java/org/wonday/orientation/OrientationModule.java
+++ b/android/src/main/java/org/wonday/orientation/OrientationModule.java
@@ -16,6 +16,7 @@ import android.content.Intent;
 import android.content.IntentFilter;
 import android.content.pm.ActivityInfo;
 import android.hardware.SensorManager;
+import android.os.Build;
 import android.view.Display;
 import android.view.OrientationEventListener;
 import android.view.Surface;
@@ -354,7 +355,7 @@ public class OrientationModule extends ReactContextBaseJavaModule implements Ori
     public void start() {
         FLog.i(ReactConstants.TAG, "orientation detect enabled.");
         mOrientationListener.enable();
-        ctx.registerReceiver(mReceiver, new IntentFilter("onConfigurationChanged"));
+        compatRegisterReceiver(ctx, mReceiver, new IntentFilter("onConfigurationChanged"), false);
         isConfigurationChangeReceiverRegistered = true;
     }
 
@@ -400,4 +401,23 @@ public class OrientationModule extends ReactContextBaseJavaModule implements Ori
     public void removeListeners(Integer count) {
      // Keep: Required for RN built in Event Emitter Calls.
     }
+
+    /**
+   * Starting with Android 14, apps and services that target Android 14 and use context-registered
+   * receivers are required to specify a flag to indicate whether or not the receiver should be
+   * exported to all other apps on the device: either RECEIVER_EXPORTED or RECEIVER_NOT_EXPORTED
+   *
+   * <p>https://developer.android.com/about/versions/14/behavior-changes-14#runtime-receivers-exported
+   */
+    private void compatRegisterReceiver(
+        Context context, BroadcastReceiver receiver, IntentFilter filter, boolean exported) {
+        if (Build.VERSION.SDK_INT >= 34 && context.getApplicationInfo().targetSdkVersion >= 34) {
+        context.registerReceiver(
+            receiver, filter, exported ? Context.RECEIVER_EXPORTED : Context.RECEIVER_NOT_EXPORTED);
+        } else {
+        context.registerReceiver(receiver, filter);
+        }
+    }
 }
+
+  


### PR DESCRIPTION
Add RECEIVER_EXPORTED/RECEIVER_NOT_EXPORTED flag support to DevSupportManagerBase for Android 14 change. See
https://developer.android.com/about/versions/14/behavior-changes-14#runtime-receivers-exported for details.

Without this fix, app crashes during launch because of :
```SecurityException: {package name here}: One of RECEIVER_EXPORTED or RECEIVER_NOT_EXPORTED should be specified when a receiver isn't being registered exclusively for system broadcasts```