### PR TITLE
Fix reporting UI orientation upon unlock

### DIFF
--- a/android/src/main/java/org/wonday/orientation/OrientationModule.java
+++ b/android/src/main/java/org/wonday/orientation/OrientationModule.java
@@ -312,7 +312,7 @@ public class OrientationModule extends ReactContextBaseJavaModule implements Ori
         isLocked = false;
 
         //force send an UI orientation event when unlock
-        lastOrientationValue = lastDeviceOrientationValue;
+        lastOrientationValue = getCurrentOrientation();
         WritableMap params = Arguments.createMap();
         params.putString("orientation", lastOrientationValue);
         if (ctx.hasActiveCatalystInstance()) {


### PR DESCRIPTION
We noticed the orientation listener reported the device orientation instead of the UI orientation after `unlockAllOrientations` was called. 
This was noticeable on Android devices with the rotation locked: UI in Portrait, device in Landscape