### PR TITLE
Remove Unnecessary Namespace Declaration from build.gradle in Version 1.0.6

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -5,7 +5,6 @@ def safeExtGet(prop, fallback) {
 }
 
 android {
-    namespace = "org.wonday.orientation"
     compileSdkVersion safeExtGet('compileSdkVersion', 27)
     buildToolsVersion safeExtGet('buildToolsVersion', '27.0.3')
 


### PR DESCRIPTION
## Overview
This PR addresses an issue found in version 1.0.6 of the `react-native-orientation-locker` package, where the `namespace` declaration in `android/build.gradle` file is present, but should not be according to the latest version requirements.

## Changes
- Removed the `namespace = "org.wonday.orientation"` line from the `android/build.gradle` file.

## Reason
The presence of the `namespace` declaration in the `build.gradle` file is not required in the latest versions of React Native and can lead to build issues or conflicts. This change aims to align the package with the current standards and practices for React Native development, ensuring better compatibility and stability.

## Testing
- The changes have been tested locally to ensure that the removal of the namespace declaration does not affect the functionality of the package.
- Ensured that the package builds correctly without the namespace line and functions as expected in a sample React Native project.
- With this fix, known build issues related to the namespace declaration have been resolved. However, edge cases have not been extensively tested. Further testing might be necessary to ensure full compatibility and functionality across various scenarios.

Looking forward to your feedback and suggestions on this change.
