### PR TITLE
Add support for new iOS orientation API on newer OS versions

### DIFF
--- a/iOS/RCTOrientation/Orientation.m
+++ b/iOS/RCTOrientation/Orientation.m
@@ -39,7 +39,7 @@ static UIInterfaceOrientationMask _orientationMask = UIInterfaceOrientationMaskA
 - (instancetype)init
 {
     if ((self = [super init])) {
-        _lastOrientation = [UIApplication sharedApplication].statusBarOrientation;;
+        _lastOrientation = [self getInterfaceOrientation];
         _lastDeviceOrientation = [self getDeviceOrientation];
         _isLocking = NO;
         _disableFaceUpDown = NO;
@@ -56,12 +56,34 @@ static UIInterfaceOrientationMask _orientationMask = UIInterfaceOrientationMaskA
     [self removeListeners:1];
 }
 
+- (UIInterfaceOrientation)getInterfaceOrientation
+{
+    if(@available(iOS 13, *)) {
+        UIInterfaceOrientation orientation = UIInterfaceOrientationUnknown;
+        UIScene *activeScene = [[UIApplication sharedApplication] connectedScenes].allObjects.firstObject;
+        if ([activeScene isKindOfClass:[UIWindowScene class]]) {
+            UIWindowScene *windowScene = (UIWindowScene *)activeScene;
+            orientation = windowScene.interfaceOrientation;
+        }
+        
+#if DEBUG
+        if(orientation == UIInterfaceOrientationUnknown) {
+            NSLog(@"Device orientation is unknown.");
+        }
+#endif
+        
+        return orientation;
+    } else {
+        return [UIApplication sharedApplication].statusBarOrientation;
+    }
+}
+
 - (UIInterfaceOrientation)getDeviceOrientation {
     UIInterfaceOrientation deviceOrientation = (UIInterfaceOrientation) [UIDevice currentDevice].orientation;
     
     BOOL isFaceUpDown = deviceOrientation == UIDeviceOrientationFaceUp || deviceOrientation == UIDeviceOrientationFaceDown;
     if (_disableFaceUpDown && isFaceUpDown) {
-        return [UIApplication sharedApplication].statusBarOrientation;
+        return [self getInterfaceOrientation];
     }
     
     return deviceOrientation;
@@ -69,7 +91,7 @@ static UIInterfaceOrientationMask _orientationMask = UIInterfaceOrientationMaskA
 
 - (void)deviceOrientationDidChange:(NSNotification *)notification
 {
-    UIInterfaceOrientation orientation = [UIApplication sharedApplication].statusBarOrientation;
+    UIInterfaceOrientation orientation = [self getInterfaceOrientation];
     UIInterfaceOrientation deviceOrientation = [self getDeviceOrientation];
     
     // do not send Unknown Orientation
@@ -94,35 +116,29 @@ static UIInterfaceOrientationMask _orientationMask = UIInterfaceOrientationMaskA
     NSString *orientationStr;
     switch (orientation) {
         case UIInterfaceOrientationPortrait:
-            
             orientationStr = @"PORTRAIT";
             break;
             
         case UIInterfaceOrientationLandscapeLeft:
-            
             orientationStr = @"LANDSCAPE-RIGHT";
             break;
             
         case UIInterfaceOrientationLandscapeRight:
-            
             orientationStr = @"LANDSCAPE-LEFT";
             break;
             
         case UIInterfaceOrientationPortraitUpsideDown:
-            
             orientationStr = @"PORTRAIT-UPSIDEDOWN";
             break;
-        
+            
         case UIDeviceOrientationFaceUp:
-
             orientationStr = @"FACE-UP";
             break;
-
+            
         case UIDeviceOrientationFaceDown:
-        
             orientationStr = @"FACE-DOWN";
             break;
-
+            
         default:
             orientationStr = @"UNKNOWN";
             break;
@@ -135,18 +151,31 @@ static UIInterfaceOrientationMask _orientationMask = UIInterfaceOrientationMaskA
     _isLocking = YES;
     NSString* orientation = @"orientation";
     
-    UIInterfaceOrientation deviceOrientation = _lastDeviceOrientation;
-    
     [Orientation setOrientation:mask];
-    UIDevice* currentDevice = [UIDevice currentDevice];
     
-    [currentDevice setValue:@(UIInterfaceOrientationUnknown) forKey:orientation];
-    [currentDevice setValue:@(newOrientation) forKey:orientation];
+    if (@available(iOS 16.0, *)) {
+        UIWindowScene *windowScene = (UIWindowScene *)[UIApplication sharedApplication].connectedScenes.allObjects.firstObject;
+        
+        UIWindowSceneGeometryPreferencesIOS *geometryPreferences = [[UIWindowSceneGeometryPreferencesIOS alloc] initWithInterfaceOrientations:mask];
+        [windowScene requestGeometryUpdateWithPreferences:geometryPreferences errorHandler:^(NSError * _Nonnull error) {
+#if DEBUG
+            if (error) {
+                NSLog(@"Failed to update geometry with UIInterfaceOrientationMask: %@", error);
+            }
+#endif
+        }];
+        
+    } else {
+        UIDevice* currentDevice = [UIDevice currentDevice];
+        
+        [currentDevice setValue:@(UIInterfaceOrientationUnknown) forKey:orientation];
+        [currentDevice setValue:@(newOrientation) forKey:orientation];
+    }
     
     [UIViewController attemptRotationToDeviceOrientation];
-    
+        
     [self sendEventWithName:@"lockDidChange" body:@{orientation: [self getOrientationStr:newOrientation]}];
-    
+
     _isLocking = NO;
 }
 
@@ -176,40 +205,40 @@ RCT_EXPORT_METHOD(configure:(NSDictionary *)options)
 RCT_EXPORT_METHOD(getOrientation:(RCTResponseSenderBlock)callback)
 {
 #if (!TARGET_OS_TV)
-    [[NSOperationQueue mainQueue] addOperationWithBlock:^ {
-        UIInterfaceOrientation orientation = [UIApplication sharedApplication].statusBarOrientation;
+    dispatch_async(dispatch_get_main_queue(), ^{
+        UIInterfaceOrientation orientation = [self getInterfaceOrientation];
         NSString *orientationStr = [self getOrientationStr:orientation];
         callback(@[orientationStr]);
-    }];
+    });
 #endif
 }
 
 RCT_EXPORT_METHOD(getDeviceOrientation:(RCTResponseSenderBlock)callback)
 {
 #if (!TARGET_OS_TV)
-    [[NSOperationQueue mainQueue] addOperationWithBlock:^ {
+    dispatch_async(dispatch_get_main_queue(), ^{
         UIInterfaceOrientation deviceOrientation = [self getDeviceOrientation];
         NSString *orientationStr = [self getOrientationStr:deviceOrientation];
         callback(@[orientationStr]);
-    }];
+    });
 #endif
 }
 
 RCT_EXPORT_METHOD(lockToPortrait)
 {
 #if (!TARGET_OS_TV)
-    [[NSOperationQueue mainQueue] addOperationWithBlock:^ {
+    dispatch_async(dispatch_get_main_queue(), ^{
         [self lockToOrientation:UIInterfaceOrientationPortrait usingMask:UIInterfaceOrientationMaskPortrait];
-    }];
+    });
 #endif
 }
 
 RCT_EXPORT_METHOD(lockToPortraitUpsideDown)
 {
 #if (!TARGET_OS_TV)
-    [[NSOperationQueue mainQueue] addOperationWithBlock:^ {
+    dispatch_async(dispatch_get_main_queue(), ^{
         [self lockToOrientation:UIInterfaceOrientationPortraitUpsideDown usingMask:UIInterfaceOrientationMaskPortraitUpsideDown];
-    }];
+    });
 #endif
 }
 
@@ -220,14 +249,13 @@ RCT_EXPORT_METHOD(lockToLandscape)
 #endif
     
 #if (!TARGET_OS_TV)
-    [[NSOperationQueue mainQueue] addOperationWithBlock:^ {
-        
+    dispatch_async(dispatch_get_main_queue(), ^{
         // set a flag so that no deviceOrientationDidChange events are sent to JS
-        _isLocking = YES;
+        self->_isLocking = YES;
         
-        UIInterfaceOrientation deviceOrientation = _lastDeviceOrientation;
+        UIInterfaceOrientation deviceOrientation = self->_lastDeviceOrientation;
         
-        UIInterfaceOrientation orientation = [UIApplication sharedApplication].statusBarOrientation;
+        UIInterfaceOrientation orientation = [self getInterfaceOrientation];
         NSString *orientationStr = [self getOrientationStr:orientation];
         
         // when call lockXXX, make sure to sent orientationDidChange event to JS
@@ -249,9 +277,8 @@ RCT_EXPORT_METHOD(lockToLandscape)
         // send a lock event
         [self sendEventWithName:@"lockDidChange" body:@{@"orientation":@"LANDSCAPE-LEFT"}];
         
-        _isLocking = NO;
-        
-    }];
+        self->_isLocking = NO;
+    });
 #endif
 }
 
@@ -262,9 +289,9 @@ RCT_EXPORT_METHOD(lockToLandscapeRight)
 #endif
     
 #if (!TARGET_OS_TV)
-    [[NSOperationQueue mainQueue] addOperationWithBlock:^ {
+    dispatch_async(dispatch_get_main_queue(), ^{
         [self lockToOrientation:UIInterfaceOrientationLandscapeLeft usingMask:UIInterfaceOrientationMaskLandscapeLeft];
-    }];
+    });
 #endif
 }
 
@@ -274,9 +301,9 @@ RCT_EXPORT_METHOD(lockToLandscapeLeft)
     NSLog(@"Locking to Landscape Left");
 #endif
 #if (!TARGET_OS_TV)
-    [[NSOperationQueue mainQueue] addOperationWithBlock:^ {
+    dispatch_async(dispatch_get_main_queue(), ^{
         [self lockToOrientation:UIInterfaceOrientationLandscapeRight usingMask:UIInterfaceOrientationMaskLandscapeRight];
-    }];
+    });
 #endif
 }
 
@@ -286,9 +313,9 @@ RCT_EXPORT_METHOD(lockToAllOrientationsButUpsideDown)
     NSLog(@"Locking to all except upside down");
 #endif
 #if (!TARGET_OS_TV)
-    [[NSOperationQueue mainQueue] addOperationWithBlock:^ {
+    dispatch_async(dispatch_get_main_queue(), ^{
         [self lockToOrientation:UIInterfaceOrientationPortrait usingMask:UIInterfaceOrientationMaskAllButUpsideDown];
-    }];
+    });
 #endif
 }
 
@@ -299,16 +326,16 @@ RCT_EXPORT_METHOD(unlockAllOrientations)
 #endif
     
 #if (!TARGET_OS_TV)
-    [[NSOperationQueue mainQueue] addOperationWithBlock:^ {
+    dispatch_async(dispatch_get_main_queue(), ^{
         [self lockToOrientation:UIInterfaceOrientationUnknown usingMask:UIInterfaceOrientationMaskAll];
-    }];
+    });
 #endif
 }
 
 - (NSDictionary *)constantsToExport
 {
 #if (!TARGET_OS_TV)
-    UIInterfaceOrientation orientation = [UIApplication sharedApplication].statusBarOrientation;
+    UIInterfaceOrientation orientation = [self getInterfaceOrientation];
     NSString *orientationStr = [self getOrientationStr:orientation];
     
     return @{@"initialOrientation": orientationStr};


### PR DESCRIPTION
Hello I've updated the Orientation.mm file to support the new iOS orientation API. We currently have these changes patched in our project but it would be nice to get these fixes merged into the actual package.

Changes:
- Checking orientation by using `statusBarOrientation` is deprecated in > iOS 13. Updated to get interfaceOrientation from UIWindowScene on newer iOS versions.
- Updating orientation on >iOS16 by updating UIDevice is deprecated. Changed that newer iOS versions attempts updating the UIWindowSceneGeometryPreferencesIOS instead.

Let me know if there is any issues with these changes @wonday , thanks :) 
