### PR TITLE
fix: properly get window scene to avoid crash on CarPlay app

### DIFF
--- a/iOS/RCTOrientation/Orientation.m
+++ b/iOS/RCTOrientation/Orientation.m
@@ -60,8 +60,8 @@ static UIInterfaceOrientationMask _orientationMask = UIInterfaceOrientationMaskA
 {
     if(@available(iOS 13, *)) {
         UIInterfaceOrientation orientation = UIInterfaceOrientationUnknown;
-        UIScene *activeScene = [[UIApplication sharedApplication] connectedScenes].allObjects.firstObject;
-        if ([activeScene isKindOfClass:[UIWindowScene class]]) {
+        UIWindowScene *activeScene = [self getWindowScene];
+        if (activeScene != nil && [activeScene isKindOfClass:[UIWindowScene class]]) {
             UIWindowScene *windowScene = (UIWindowScene *)activeScene;
             orientation = windowScene.interfaceOrientation;
         }
@@ -111,6 +111,16 @@ static UIInterfaceOrientationMask _orientationMask = UIInterfaceOrientationMaskA
     }
 }
 
+- (UIWindowScene *)getWindowScene {
+    NSArray *array = [[[UIApplication sharedApplication] connectedScenes] allObjects];
+    for (id connectedScene in array) {
+      if ([connectedScene isKindOfClass:[UIWindowScene class]]) {
+        return connectedScene;
+      }
+    }
+    return nil;
+}
+
 - (NSString *)getOrientationStr: (UIInterfaceOrientation)orientation {
     
     NSString *orientationStr;
@@ -154,17 +164,17 @@ static UIInterfaceOrientationMask _orientationMask = UIInterfaceOrientationMaskA
     [Orientation setOrientation:mask];
     
     if (@available(iOS 16.0, *)) {
-        UIWindowScene *windowScene = (UIWindowScene *)[UIApplication sharedApplication].connectedScenes.allObjects.firstObject;
-        
-        UIWindowSceneGeometryPreferencesIOS *geometryPreferences = [[UIWindowSceneGeometryPreferencesIOS alloc] initWithInterfaceOrientations:mask];
-        [windowScene requestGeometryUpdateWithPreferences:geometryPreferences errorHandler:^(NSError * _Nonnull error) {
+        UIWindowScene *windowScene = [self getWindowScene];
+        if (windowScene != nil) {
+            UIWindowSceneGeometryPreferencesIOS *geometryPreferences = [[UIWindowSceneGeometryPreferencesIOS alloc] initWithInterfaceOrientations:mask];
+            [windowScene requestGeometryUpdateWithPreferences:geometryPreferences errorHandler:^(NSError * _Nonnull error) {
 #if DEBUG
-            if (error) {
-                NSLog(@"Failed to update geometry with UIInterfaceOrientationMask: %@", error);
-            }
+                if (error) {
+                    NSLog(@"Failed to update geometry with UIInterfaceOrientationMask: %@", error);
+                }
 #endif
-        }];
-        
+            }];
+        }
     } else {
         UIDevice* currentDevice = [UIDevice currentDevice];
         


### PR DESCRIPTION
This PR is aimed to solve the issue that app crashes if it's opened from iOS CarPlay. When invoking lockToXXX functions, `lockToOrientation` will try to get the first scene from the `connectedScenes`, if the app is opened from CarPlay, the first scene will be a `CPTemplateApplicationScene ` instance, which causes the crash below.

```
NSInvalidArgumentException
-[CPTemplateApplicationScene requestGeometryUpdateWithPreferences:errorHandler:]: unrecognized selector sent to instance 0x122b1aca0
```

react-native-screens has a similar issue which got solved by [this PR](https://github.com/software-mansion/react-native-screens/commit/58da3e2cb884fecd4d6ae9b51a45e9d596621fc6)