### PR TITLE
Honor the system orientation lock #144

### DIFF
--- a/android/src/main/java/org/wonday/orientation/OrientationModule.java
+++ b/android/src/main/java/org/wonday/orientation/OrientationModule.java
@@ -309,7 +309,7 @@ public class OrientationModule extends ReactContextBaseJavaModule implements Ori
 
         final Activity activity = getCurrentActivity();
         if (activity == null) return;
-        activity.setRequestedOrientation(ActivityInfo.SCREEN_ORIENTATION_SENSOR);
+        activity.setRequestedOrientation(ActivityInfo.SCREEN_ORIENTATION_UNSPECIFIED);
         isLocked = false;
 
         //force send an UI orientation event when unlock


### PR DESCRIPTION
Revert "Fix unlockAllOrientations on Android (#133)"

This reverts commit 7a7db411d7da08efc08590883716b1dd2286fb37.

Refer to the issue for more information, particularly this comment: https://github.com/wonday/react-native-orientation-locker/issues/144#issuecomment-1303216433